### PR TITLE
[release] max limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Yet another [thirdy party package for DRF Pagination](https://www.django-rest-framework.org/api-guide/pagination/). 
 
+## X-Drf-Change-Domain
 If you want to change de host address located on `next` and `previous` fields, then this is the right thing to you. Take this body as an example:
 
 ```json
@@ -26,6 +27,37 @@ Using a reverse proxy (like AWS API Gateway) to intermediate between your API, a
   "links": {
     "next": "http://chumaco/api/v1/entities/?limit=1&offset=2",
     "previous": "http://chumaco/api/v1/entities/limit=1"
+  },
+  "count": 100,
+  "results": [
+    {
+      "id": "bc6c6868-4e4d-4381-a785-f353ee7ecce5"
+    }
+  ]
+}
+```
+## X-Drf-Max-Pagination-Size
+This header allows you to define different limits to the pagination depending on the gateway you are exposing your API.
+For example. For **client A** we allow a max of `50` entries, for **client B** we allow a max of `100` you can by injecting 
+this header on the client's requests.
+
+If for some reason the client exceeds the limit he will receive a Bad Request Error:
+```json
+{
+    "detail": "Bad limit value sent.",
+    "error": {
+        "code": "bad_limit_value"
+    },
+    "type": "API_EXCEPTION"
+}
+```
+
+Otherwise the default paginated  response is generated:
+```json
+{
+  "links": {
+    "next": "https://chumaco/api/v1/entities/?limit=1&offset=2",
+    "previous": "https://chumaco/api/v1/entities/limit=1"
   },
   "count": 100,
   "results": [

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # DRF Link Navigation Pagination
 
-Yet another [thirdy party package for DRF Pagination](https://www.django-rest-framework.org/api-guide/pagination/). 
+Yet another [thirdy party package for DRF Pagination](https://www.django-rest-framework.org/api-guide/pagination/).
+
+This package adds support to some headers that allow you to configure the behaviour of the LimitOffsetPagination class.
 
 ## X-Drf-Change-Domain
 If you want to change de host address located on `next` and `previous` fields, then this is the right thing to you. Take this body as an example:
@@ -70,7 +72,13 @@ Otherwise the default paginated  response is generated:
 
 # Configuration process
 
-Not yet fully available, but feel free to see our tests to get insights.
+To use this package after installing you need to use it's pagination class. in your `settings.py` do the following:
+```python
+REST_FRAMEWORK = {
+    "DEFAULT_PAGINATION_CLASS": "drf_link_navigation_pagination.LinkNavigationPagination",
+    ...
+}
+```
 
 ## Tests
 

--- a/drf_link_navigation_pagination/__init__.py
+++ b/drf_link_navigation_pagination/__init__.py
@@ -42,11 +42,13 @@ class LinkNavigationPagination(LimitOffsetPagination):
 
     def paginate_queryset(self, queryset, request, view=None):
         if request.headers.get(self.header_max_pagination_size) is not None:
-            # https://www.django-rest-framework.org/api-guide/pagination/#limitoffsetpagination
-            self.max_limit = request.headers.get(self.header_max_pagination_size)
-
-            if int(request.query_params[self.limit_query_param]) > self.max_limit:
-                raise BadLimitValue()
+            try:
+                # https://www.django-rest-framework.org/api-guide/pagination/#limitoffsetpagination
+                self.max_limit = int(request.headers.get(self.header_max_pagination_size))
+                if int(request.query_params.get(self.limit_query_param, 0)) > self.max_limit:
+                    raise BadLimitValue()
+            except ValueError:
+                pass
 
         return super().paginate_queryset(queryset, request, view)
 

--- a/drf_link_navigation_pagination/__init__.py
+++ b/drf_link_navigation_pagination/__init__.py
@@ -32,9 +32,17 @@ class LinkNavigationPagination(LimitOffsetPagination):
         if hasattr(settings, "DRF_LNP_HEADER_NUMBER_OF_OVERLAP_PATHS")
         else "X-Drf-Number-Overlap-Paths"
     )
+    header_max_pagination_size = (
+        settings.DRF_MAX_PAGINATION_SIZE
+        if hasattr(settings, "DRF_MAX_PAGINATION_SIZE")
+        else "X-Drf-Max-Pagination-Size"
+    )
 
     def get_paginated_response(self, data, *args, **kwargs):
         logger.debug("Getting answer from super")
+        if self.header_max_pagination_size is not None:
+            # https://www.django-rest-framework.org/api-guide/pagination/#limitoffsetpagination
+            self.max_limit = self.header_max_pagination_size
         response_from_super = super().get_paginated_response(data)
 
         next_page = response_from_super.data["next"]

--- a/drf_link_navigation_pagination/__init__.py
+++ b/drf_link_navigation_pagination/__init__.py
@@ -5,9 +5,9 @@ from urllib.parse import urlparse
 
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
-from rest_framework.pagination import LimitOffsetPagination
-from rest_framework.exceptions import APIException
 from rest_framework import status
+from rest_framework.exceptions import APIException
+from rest_framework.pagination import LimitOffsetPagination
 
 logger = logging.getLogger("drf_link_navigation_pagination")
 
@@ -18,8 +18,8 @@ def _eval_str_as_boolean(value: str):
 
 class BadLimitValue(APIException):
     status_code = status.HTTP_400_BAD_REQUEST
-    default_detail = _('Bad limit value sent.')
-    default_code = 'bad_limit_value'
+    default_detail = _("Bad limit value sent.")
+    default_code = "bad_limit_value"
 
 
 class LinkNavigationPagination(LimitOffsetPagination):

--- a/drf_link_navigation_pagination/__init__.py
+++ b/drf_link_navigation_pagination/__init__.py
@@ -1,4 +1,5 @@
 import logging
+from contextlib import suppress
 from pathlib import PurePosixPath
 from urllib.parse import unquote
 from urllib.parse import urlparse
@@ -44,11 +45,9 @@ class LinkNavigationPagination(LimitOffsetPagination):
         if request.headers.get(self.header_max_pagination_size) is not None:
             # https://www.django-rest-framework.org/api-guide/pagination/#limitoffsetpagination
             self.max_limit = int(request.headers.get(self.header_max_pagination_size))
-            try:
+            with suppress(ValueError):
                 if int(request.query_params.get(self.limit_query_param, 0)) > self.max_limit:
                     raise BadLimitValue()
-            except ValueError:
-                pass
         return super().paginate_queryset(queryset, request, view)
 
     def get_paginated_response(self, data, *args, **kwargs):

--- a/drf_link_navigation_pagination/__init__.py
+++ b/drf_link_navigation_pagination/__init__.py
@@ -4,22 +4,15 @@ from urllib.parse import unquote
 from urllib.parse import urlparse
 
 from django.conf import settings
-from django.utils.translation import gettext_lazy as _
-from rest_framework import status
-from rest_framework.exceptions import APIException
 from rest_framework.pagination import LimitOffsetPagination
+
+from drf_link_navigation_pagination.exceptions import BadLimitValue
 
 logger = logging.getLogger("drf_link_navigation_pagination")
 
 
 def _eval_str_as_boolean(value: str):
     return str(value).lower() in ("true", "1", "t", "y")
-
-
-class BadLimitValue(APIException):
-    status_code = status.HTTP_400_BAD_REQUEST
-    default_detail = _("Bad limit value sent.")
-    default_code = "bad_limit_value"
 
 
 class LinkNavigationPagination(LimitOffsetPagination):

--- a/drf_link_navigation_pagination/__init__.py
+++ b/drf_link_navigation_pagination/__init__.py
@@ -42,14 +42,13 @@ class LinkNavigationPagination(LimitOffsetPagination):
 
     def paginate_queryset(self, queryset, request, view=None):
         if request.headers.get(self.header_max_pagination_size) is not None:
+            # https://www.django-rest-framework.org/api-guide/pagination/#limitoffsetpagination
+            self.max_limit = int(request.headers.get(self.header_max_pagination_size))
             try:
-                # https://www.django-rest-framework.org/api-guide/pagination/#limitoffsetpagination
-                self.max_limit = int(request.headers.get(self.header_max_pagination_size))
                 if int(request.query_params.get(self.limit_query_param, 0)) > self.max_limit:
                     raise BadLimitValue()
             except ValueError:
                 pass
-
         return super().paginate_queryset(queryset, request, view)
 
     def get_paginated_response(self, data, *args, **kwargs):

--- a/drf_link_navigation_pagination/exceptions.py
+++ b/drf_link_navigation_pagination/exceptions.py
@@ -1,0 +1,9 @@
+from django.utils.translation import gettext_lazy as _
+from rest_framework import status
+from rest_framework.exceptions import APIException
+
+
+class BadLimitValue(APIException):
+    status_code = status.HTTP_400_BAD_REQUEST
+    default_detail = _("Bad limit value sent.")
+    default_code = "bad_limit_value"

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="drf-link-navigation-pagination",
-    version="0.0.4",
+    version="0.1.0",
     description="Yet another pagination class for DRF to set host address by header",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -192,6 +192,28 @@ def test_should_set_max_limit_if_received_the_header(client, pagination_size, li
 
 
 @pytest.mark.django_db
+@pytest.mark.parametrize(
+    "pagination_size,limit,returned_elements_count",
+    [
+        (10, 10, 10),
+        (10, 1, 1),
+        # defaults to default limit (aka the page size on the settings)
+        (10, -1, 5),
+        (20, 11, 11),
+        (None, 200, 200),
+        (None, 300, 200)
+    ],
+)
+def test_should_return_only_up_to_limit_elements(client, pagination_size, limit, returned_elements_count):
+    headers = {"HTTP_X_DRF_MAX_PAGINATION_SIZE": pagination_size}
+
+    response = client.get(f"/data/?limit={limit}", **headers)
+
+    assert response.status_code == status.HTTP_200_OK
+    assert len(response.json()["results"]) == returned_elements_count
+
+
+@pytest.mark.django_db
 def test_should_work_if_no_limit_is_present(client):
     headers = {"HTTP_X_DRF_MAX_PAGINATION_SIZE": "10"}
 

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -180,7 +180,7 @@ def test_should_overlap_3_paths():
         (10, -1, status.HTTP_200_OK),
         (20, 11, status.HTTP_200_OK),
         (20, 21, status.HTTP_400_BAD_REQUEST),
-        (None, 200, status.HTTP_200_OK),
+        (None, 200, status.HTTP_200_OK)
     ],
 )
 def test_should_set_max_limit_if_received_the_header(client, pagination_size, limit, expected_status):
@@ -189,3 +189,12 @@ def test_should_set_max_limit_if_received_the_header(client, pagination_size, li
     response = client.get(f"/data/?limit={limit}", **headers)
 
     assert response.status_code == expected_status
+
+
+@pytest.mark.django_db
+def test_should_work_if_no_limit_is_present(client):
+    headers = {"HTTP_X_DRF_MAX_PAGINATION_SIZE": "10"}
+
+    response = client.get(f"/data/", **headers)
+
+    assert response.status_code == status.HTTP_200_OK

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -1,8 +1,9 @@
 import json
 
 import pytest
-from drf_link_navigation_pagination import _overlap_path
 from rest_framework import status
+
+from drf_link_navigation_pagination import _overlap_path
 from tests.support.fake_django_app.models import TestModel
 
 
@@ -169,16 +170,19 @@ def test_should_overlap_3_paths():
 
 
 @pytest.mark.django_db
-@pytest.mark.parametrize('pagination_size,limit,expected_status', [
-    (10, 10, status.HTTP_200_OK),
-    (10, 1, status.HTTP_200_OK),
-    (10, 11, status.HTTP_400_BAD_REQUEST),
-    # defaults to default limit (aka the page size on the settings)
-    (10, -1, status.HTTP_200_OK),
-    (20, 11, status.HTTP_200_OK),
-    (20, 21, status.HTTP_400_BAD_REQUEST),
-    (None, 200, status.HTTP_200_OK)
-])
+@pytest.mark.parametrize(
+    "pagination_size,limit,expected_status",
+    [
+        (10, 10, status.HTTP_200_OK),
+        (10, 1, status.HTTP_200_OK),
+        (10, 11, status.HTTP_400_BAD_REQUEST),
+        # defaults to default limit (aka the page size on the settings)
+        (10, -1, status.HTTP_200_OK),
+        (20, 11, status.HTTP_200_OK),
+        (20, 21, status.HTTP_400_BAD_REQUEST),
+        (None, 200, status.HTTP_200_OK),
+    ],
+)
 def test_should_set_max_limit_if_received_the_header(client, pagination_size, limit, expected_status):
     headers = {"HTTP_X_DRF_MAX_PAGINATION_SIZE": pagination_size}
 

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -166,3 +166,12 @@ def test_should_overlap_3_paths():
         _overlap_path("http://testserver/first/second/third/fourth/fifth/?limit=1&offset=1", 4)
         == "http://testserver/fifth/?limit=1&offset=1"
     )
+
+
+@pytest.mark.django_db
+def test_should_set_max_limit_if_received_the_header(client):
+    headers = {"HTTP_X_DRF_MAX_PAGINATION_SIZE": 10}
+
+    response = client.get("/data/?limit=20", **headers)
+
+    assert response.status_code == status.HTTP_400_BAD_REQUEST


### PR DESCRIPTION
# Task
[Criar limite para o parâmetro "limit" de paginação](https://juntossomosmais.monday.com/boards/346124957/pulses/1303133319)

# What is being delivered
 - Adding support for a new header `X-Drf-Max-Pagination-Size` (This may be configured on the settings with the property `DRF_MAX_PAGINATION_SIZE`) that when present limits the "limit" param that the client can send.

# What are the impacts
N/A

# Where to monitor?
N/A