### PR TITLE
fix: adjusts trailing slash links logic

### DIFF
--- a/drf_link_navigation_pagination/__init__.py
+++ b/drf_link_navigation_pagination/__init__.py
@@ -80,8 +80,9 @@ class LinkNavigationPagination(LimitOffsetPagination):
         if request_path:
             logger.debug("Adding request path")
             has_custom_domain = bool(new_domain)
-            next_page = _add_request_path(next_page, request_path, has_custom_domain) if next_page else None
-            previous_page = _add_request_path(previous_page, request_path, has_custom_domain) if previous_page else None
+            has_overlap_paths = bool(number_of_overlap_paths)
+            next_page = _add_request_path(next_page, request_path, has_custom_domain, has_overlap_paths) if next_page else None
+            previous_page = _add_request_path(previous_page, request_path, has_custom_domain, has_overlap_paths) if previous_page else None
 
         response_from_super.data["next"] = next_page
         response_from_super.data["previous"] = previous_page
@@ -101,7 +102,7 @@ def _get_updated_url(url: str, domain: str) -> str:
     return new_parse_result.geturl()
 
 
-def _add_request_path(url: str, request_path: str, has_custom_domain: bool = False) -> str:
+def _add_request_path(url: str, request_path: str, has_custom_domain: bool = False, has_overlap_paths: bool = False) -> str:
     """"
     This function adds a request path to a URL.
     If a custom domain is also being used, the trailing slash is removed from the original path.
@@ -113,7 +114,7 @@ def _add_request_path(url: str, request_path: str, has_custom_domain: bool = Fal
     
     final_path = _urljoin(request_path, original_path)
     
-    if not has_custom_domain and has_trailing_slash:
+    if (not has_custom_domain or has_overlap_paths) and has_trailing_slash:
         final_path += "/"
     
     new_parse_result = parse_result._replace(path=final_path)
@@ -122,14 +123,20 @@ def _add_request_path(url: str, request_path: str, has_custom_domain: bool = Fal
 
 def _overlap_path(url: str, number_of_overlaps: int) -> str:
     parse_result = urlparse(url)
-    path_as_posix = PurePosixPath(unquote(urlparse(url).path))
+    original_path = parse_result.path
+    
+    path_as_posix = PurePosixPath(unquote(original_path))
     if len(path_as_posix.parts) > 1:
         number_of_overlaps += 1
         new_parts = path_as_posix.parts[number_of_overlaps:]
-        if len(new_parts) == 0:
-            final_path = path_as_posix.parts[0]
-        else:
-            final_path = path_as_posix.parts[0] + "/".join(new_parts) + path_as_posix.parts[0]
+        final_path = path_as_posix.parts[0]
+        
+        if len(new_parts) > 0:
+            final_path += "/".join(new_parts)
+        
+        if original_path.endswith("/") and not final_path.endswith("/"):
+            final_path += "/"
+            
         new_parse_result = parse_result._replace(path=final_path)
         return new_parse_result.geturl()
     return parse_result.geturl()

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
 
 setup(
     name="drf-link-navigation-pagination",
-    version="1.0.1",
+    version="1.0.2",
     description="Yet another pagination class for DRF to set host address by header",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/tests/integration/test_init.py
+++ b/tests/integration/test_init.py
@@ -201,20 +201,117 @@ def test_should_work_if_no_limit_is_present(client):
 @pytest.mark.django_db
 @pytest.mark.parametrize("request_path", ["data-with-slash/", "data-no-slash"])
 @pytest.mark.parametrize("append_slash", [True, False])
-def test_should_receive_updated_url_for_next_and_previous_with_trailing_slash_given_force_https(client, request_path, append_slash, settings):
-    custom_request_path = "salted-path"
-    headers = {"HTTP_X_DRF_ADD_REQUEST_PATH": custom_request_path}
+@pytest.mark.parametrize("header_config", [
+    pytest.param({
+        "name": "all_headers",
+        "headers": {
+            "HTTP_X_DRF_ADD_REQUEST_PATH": "salted-path",
+            "HTTP_X_DRF_NUMBER_OVERLAP_PATHS": 1,
+            "HTTP_X_DRF_CHANGE_DOMAIN": "salted-man"
+        },
+        "expected_domain": "salted-man",
+        "expected_path": "salted-path/{request_path}"
+    }, id="custom_domain+request_path+overlap"),
+    pytest.param({
+        "name": "request_path_and_overlap",
+        "headers": {
+            "HTTP_X_DRF_ADD_REQUEST_PATH": "salted-path",
+            "HTTP_X_DRF_NUMBER_OVERLAP_PATHS": 1
+        },
+        "expected_domain": "testserver",
+        "expected_path": "salted-path/{request_path}"
+    }, id="request_path+overlap"),
+    pytest.param({
+        "name": "overlap_only",
+        "headers": {
+            "HTTP_X_DRF_NUMBER_OVERLAP_PATHS": 1
+        },
+        "expected_domain": "testserver",
+        "expected_path": "{request_path}"
+    }, id="overlap_only"),
+    pytest.param({
+        "name": "request_path_only",
+        "headers": {
+            "HTTP_X_DRF_ADD_REQUEST_PATH": "salted-path"
+        },
+        "expected_domain": "testserver",
+        "expected_path": "salted-path/api/{request_path}"
+    }, id="request_path_only"),
+    pytest.param({
+        "name": "custom_domain_only",
+        "headers": {
+            "HTTP_X_DRF_CHANGE_DOMAIN": "salted-man"
+        },
+        "expected_domain": "salted-man",
+        "expected_path": "api/{request_path}"
+    }, id="custom_domain_only"),
+    pytest.param({
+        "name": "custom_domain_and_overlap",
+        "headers": {
+            "HTTP_X_DRF_NUMBER_OVERLAP_PATHS": 1,
+            "HTTP_X_DRF_CHANGE_DOMAIN": "salted-man"
+        },
+        "expected_domain": "salted-man",
+        "expected_path": "{request_path}"
+    }, id="custom_domain+overlap"),
+    pytest.param({
+        "name": "multiple_overlap_paths",
+        "headers": {
+            "HTTP_X_DRF_NUMBER_OVERLAP_PATHS": 2
+        },
+        "expected_domain": "testserver",
+        "expected_path": ""
+    }, id="multiple_overlap_paths"),
+    pytest.param({
+        "name": "custom_domain_with_multiple_overlap",
+        "headers": {
+            "HTTP_X_DRF_NUMBER_OVERLAP_PATHS": 2,
+            "HTTP_X_DRF_CHANGE_DOMAIN": "salted-man"
+        },
+        "expected_domain": "salted-man",
+        "expected_path": ""
+    }, id="custom_domain+multiple_overlap"),
+    pytest.param({
+        "name": "request_path_with_multiple_overlap",
+        "headers": {
+            "HTTP_X_DRF_ADD_REQUEST_PATH": "salted-path",
+            "HTTP_X_DRF_NUMBER_OVERLAP_PATHS": 2
+        },
+        "expected_domain": "testserver",
+        "expected_path": "salted-path//"
+    }, id="request_path+multiple_overlap"),
+    pytest.param({
+        "name": "all_headers_with_multiple_overlap",
+        "headers": {
+            "HTTP_X_DRF_ADD_REQUEST_PATH": "salted-path",
+            "HTTP_X_DRF_NUMBER_OVERLAP_PATHS": 2,
+            "HTTP_X_DRF_CHANGE_DOMAIN": "salted-man"
+        },
+        "expected_domain": "salted-man",
+        "expected_path": "salted-path//"
+    }, id="all_headers+multiple_overlap"),
+    pytest.param({
+        "name": "no_headers",
+        "headers": {},
+        "expected_domain": "testserver",
+        "expected_path": "api/{request_path}"
+    }, id="no_headers")
+])
+def test_trailing_slash_behavior_with_multiple_headers(client, request_path, append_slash, header_config, settings):
     settings.APPEND_SLASH = append_slash
 
     def _do_execute_and_assert(with_https: bool):
         custom_headers = {"HTTP_X_DRF_FORCE_HTTPS": with_https}
-        custom_headers.update(headers)
+        custom_headers.update(header_config["headers"])
         scheme = "https" if with_https else "http"
 
-        response = client.get(f"/{request_path}?limit=1", **custom_headers)
+        response = client.get(f"/api/{request_path}?limit=1", **custom_headers)
+        
+        expected_next = f"{scheme}://{header_config['expected_domain']}/{header_config['expected_path'].format(request_path=request_path)}?limit=1&offset=1"
+        
         assert response.status_code and json.loads(response.content) == {
             "count": 200,
-            "next": f"{scheme}://testserver/{custom_request_path}/{request_path}?limit=1&offset=1",
+            "next": expected_next,
             "previous": None,
             "results": [{"id": 1, "some_integer": 1}],
         }

--- a/tests/support/fake_django_app/urls.py
+++ b/tests/support/fake_django_app/urls.py
@@ -8,6 +8,6 @@ router.register(r"data", TestViewSet)
 
 urlpatterns = [
     path(r"", include(router.urls)),
-    path(r"data-no-slash", TestListViewSet.as_view(), name='data-no-slash'),
-    path(r"data-with-slash/", TestListViewSet.as_view(), name='data-with-slash'),
+    path(r"api/data-no-slash", TestListViewSet.as_view(), name='data-no-slash'),
+    path(r"api/data-with-slash/", TestListViewSet.as_view(), name='data-with-slash'),
 ]


### PR DESCRIPTION
- Corrects logic to ensure the trailing slash isn't removed from URL depending on combination of multiple headers.